### PR TITLE
FIX: ocr 결과 category에 content만 고정으로 오는 문제 수정

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/dto/ocr/OcrUpdateRequest.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/dto/ocr/OcrUpdateRequest.java
@@ -13,4 +13,5 @@ public class OcrUpdateRequest {
     
     private String id;
     private String element;
+    private String category;
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/entity/OcrContent.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/entity/OcrContent.java
@@ -22,6 +22,10 @@ public class OcrContent {
     @Setter
     private String content;
 
+    @Column(name = "category")
+    @Setter
+    private String category;
+
     @Column(name = "tag_idx")
     @Setter
     private Integer tagIdx;
@@ -31,10 +35,11 @@ public class OcrContent {
     @Setter
     private Contract contract;
 
-    public OcrContent(String id, String contractId, String content, Integer tagIdx) {
+    public OcrContent(String id, String contractId, String content, String category, Integer tagIdx) {
         this.id = id;
         this.contractId = contractId;
         this.content = content;
+        this.category = category;
         this.tagIdx = tagIdx;
     }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/repository/OcrContentRepository.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/repository/OcrContentRepository.java
@@ -24,4 +24,14 @@ public interface OcrContentRepository extends JpaRepository<OcrContent, String> 
      * 계약 ID로 OCR 콘텐츠 개수 조회
      */
     long countByContractId(String contractId);
+
+    /**
+     * 계약 ID와 카테고리로 OCR 콘텐츠 목록 조회 (태그 순서대로)
+     */
+    List<OcrContent> findByContractIdAndCategoryOrderByTagIdx(String contractId, String category);
+
+    /**
+     * 계약 ID와 카테고리로 OCR 콘텐츠 개수 조회
+     */
+    long countByContractIdAndCategory(String contractId, String category);
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/OcrProcessService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/OcrProcessService.java
@@ -170,6 +170,7 @@ public class OcrProcessService {
                 IdGenerator.generate(),
                 contractId,
                 element.getHtml(),
+                element.getCategory(),
                 (pageIdx+1) * 1000 + j // tagIdx: 페이지번호*1000 + 요소순서로 정렬
             );
             
@@ -194,9 +195,9 @@ public class OcrProcessService {
         for (OcrContent content : ocrContents) {
             htmlEntire.append(content.getContent());
             htmlArray.add(new OcrContentResponse.HtmlElement(
-                "content", 
+                content.getCategory(), // 실제 category 값 사용
                 content.getContent(), 
-                content.getId(),    // OCR 콘텐츠의 ID 추가
+                content.getId(),
                 content.getTagIdx()
             ));
         }
@@ -220,6 +221,10 @@ public class OcrProcessService {
         }
         
         ocrContent.setContent(request.getElement());
+        // category가 제공된 경우에만 업데이트
+        if (request.getCategory() != null) {
+            ocrContent.setCategory(request.getCategory());
+        }
         ocrContentRepository.save(ocrContent);
     }
     

--- a/src/test/java/com/sbpb/ddobak/server/domain/documentProcess/controller/ContractControllerTest.java
+++ b/src/test/java/com/sbpb/ddobak/server/domain/documentProcess/controller/ContractControllerTest.java
@@ -85,8 +85,8 @@ class ContractControllerTest {
     void getOcrResults_Success() throws Exception {
         // given
         List<OcrContentResponse.HtmlElement> htmlArray = List.of(
-            new OcrContentResponse.HtmlElement("content", "<div>테스트 내용 1</div>", "OCR001", 1001),
-            new OcrContentResponse.HtmlElement("content", "<div>테스트 내용 2</div>", "OCR002", 1002)
+            new OcrContentResponse.HtmlElement("paragraph", "<div>테스트 내용 1</div>", "OCR001", 1001),
+            new OcrContentResponse.HtmlElement("title", "<div>테스트 내용 2</div>", "OCR002", 1002)
         );
         OcrContentResponse response = new OcrContentResponse(2, "<div>테스트 내용 1</div><div>테스트 내용 2</div>", htmlArray);
 
@@ -108,7 +108,7 @@ class ContractControllerTest {
     @DisplayName("OCR 내용 수정 API 성공")
     void updateOcrContent_Success() throws Exception {
         // given
-        OcrUpdateRequest request = new OcrUpdateRequest("OCR001", "<div>수정된 내용</div>");
+        OcrUpdateRequest request = new OcrUpdateRequest("OCR001", "<div>수정된 내용</div>", "paragraph");
 
         // when & then
         mockMvc.perform(patch("/contract/ocr/{contractId}", contractId)


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
ocr 결과 category에 content만 고정으로 오는 문제 수정

## 🔗 관련 이슈
- Closes #32 

## ✨ 변경사항
### 추가한 것
- ocr_content 엔티티에 category 필드 추가 
- 관련 로직들 추가
 