### PR TITLE
애플 로그인 테스트 API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.sbpb.ddobak.server.domain.auth.controller;
 import com.sbpb.ddobak.server.common.response.ApiResponse;
 import com.sbpb.ddobak.server.common.response.SuccessCode;
 import com.sbpb.ddobak.server.domain.auth.dto.AppleLoginRequest;
+import com.sbpb.ddobak.server.domain.auth.dto.AppleTokenVerificationResponse;
 import com.sbpb.ddobak.server.domain.auth.dto.AuthResponse;
 import com.sbpb.ddobak.server.domain.auth.service.AuthService;
 import com.sbpb.ddobak.server.domain.auth.service.JwtService;
@@ -119,5 +120,32 @@ public class AuthController {
                 ApiResponse.success(false, SuccessCode.SUCCESS)
             );
         }
+    }
+    
+    /**
+     * Apple Identity Token 검증 (테스트용)
+     * 애플로그인 연동 테스트를 위함.
+     * 토큰 검증만 수행하고 실제 사용자 생성이나 로그인은 하지 않음.
+     * @param request Apple 로그인 요청 (Identity Token 포함)
+     * @return 토큰 검증 결과와 토큰에서 추출한 정보
+     */
+    @PostMapping("/apple/verify")
+    public ResponseEntity<ApiResponse<AppleTokenVerificationResponse>> verifyAppleToken(
+        @Valid @RequestBody AppleLoginRequest request
+    ) {
+        log.info("Apple token verification request received for testing");
+        
+        AppleTokenVerificationResponse response = authService.verifyAppleToken(request);
+        
+        if (response.isValid()) {
+            log.info("Apple token verification successful for user: {} ({})", 
+                response.getEmail(), response.getUserId());
+        } else {
+            log.warn("Apple token verification failed: {}", response.getErrorMessage());
+        }
+        
+        return ResponseEntity.ok(
+            ApiResponse.success(response, SuccessCode.SUCCESS)
+        );
     }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/dto/AppleTokenVerificationResponse.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/dto/AppleTokenVerificationResponse.java
@@ -1,0 +1,65 @@
+package com.sbpb.ddobak.server.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+/**
+ * Apple Identity Token 검증 결과 응답 DTO
+ * 토큰 검증 테스트 API에서 사용
+ */
+@Getter
+@Builder
+public class AppleTokenVerificationResponse {
+    
+    /**
+     * 토큰 유효성 여부
+     */
+    private final boolean isValid;
+    
+    /**
+     * 사용자 고유 ID (sub 클레임)
+     */
+    private final String userId;
+    
+    /**
+     * 사용자 이메일 (email 클레임)
+     */
+    private final String email;
+    
+    /**
+     * 이메일 인증 여부 (email_verified 클레임)
+     */
+    private final Boolean emailVerified;
+    
+    /**
+     * 토큰 발급자 (iss 클레임)
+     */
+    private final String issuer;
+    
+    /**
+     * 토큰 대상자 (aud 클레임)
+     */
+    private final String audience;
+    
+    /**
+     * 토큰 발급 시간 (iat 클레임)
+     */
+    private final Date issuedAt;
+    
+    /**
+     * 토큰 만료 시간 (exp 클레임)
+     */
+    private final Date expiresAt;
+    
+    /**
+     * 토큰 검증 시간
+     */
+    private final Date verifiedAt;
+    
+    /**
+     * 에러 메시지 (검증 실패 시)
+     */
+    private final String errorMessage;
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleOAuthClient.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleOAuthClient.java
@@ -2,6 +2,7 @@ package com.sbpb.ddobak.server.domain.auth.oauth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import java.util.Map;
 @Slf4j
 public class AppleOAuthClient implements OAuthClient {
     
+    @Getter
     private final AppleJwtUtils appleJwtUtils;
     private final ObjectMapper objectMapper;
     

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.sbpb.ddobak.server.domain.auth.service;
 
 import com.sbpb.ddobak.server.domain.auth.dto.AppleLoginRequest;
+import com.sbpb.ddobak.server.domain.auth.dto.AppleTokenVerificationResponse;
 import com.sbpb.ddobak.server.domain.auth.dto.AuthResponse;
 
 /**
@@ -15,6 +16,14 @@ public interface AuthService {
      * @return 인증 결과 (토큰 정보 포함)
      */
     AuthResponse loginWithApple(AppleLoginRequest request);
+    
+    /**
+     * Apple Identity Token 검증 (테스트용)
+     * 토큰 검증만 수행하고 사용자 생성이나 로그인 처리는 하지 않음
+     * @param request Apple 로그인 요청 정보
+     * @return 토큰 검증 결과
+     */
+    AppleTokenVerificationResponse verifyAppleToken(AppleLoginRequest request);
     
     /**
      * 토큰 갱신

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sbpb.ddobak.server.domain.auth.service.impl;
 
 import com.sbpb.ddobak.server.domain.auth.dto.AppleLoginRequest;
+import com.sbpb.ddobak.server.domain.auth.dto.AppleTokenVerificationResponse;
 import com.sbpb.ddobak.server.domain.auth.dto.AuthResponse;
 import com.sbpb.ddobak.server.domain.auth.oauth.AppleOAuthClient;
 import com.sbpb.ddobak.server.domain.auth.oauth.OAuthUserInfo;
@@ -8,12 +9,14 @@ import com.sbpb.ddobak.server.domain.auth.service.AuthService;
 import com.sbpb.ddobak.server.domain.auth.service.JwtService;
 import com.sbpb.ddobak.server.domain.user.entity.User;
 import com.sbpb.ddobak.server.domain.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Optional;
 
 /**
@@ -107,6 +110,40 @@ public class AuthServiceImpl implements AuthService {
         } catch (Exception e) {
             log.warn("Logout processing failed: {}", e.getMessage());
             // 로그아웃은 실패해도 클라이언트에서 토큰을 삭제하면 됨
+        }
+    }
+    
+    @Override
+    public AppleTokenVerificationResponse verifyAppleToken(AppleLoginRequest request) {
+        try {
+            log.info("Verifying Apple Identity Token for test purposes");
+            
+            // Apple Identity Token 검증 및 파싱 (AppleJwtUtils를 통해 직접 접근)
+            Claims claims = appleOAuthClient.getAppleJwtUtils().parseAndValidateToken(request.getIdentityToken());
+            
+            // 검증 성공 응답 생성
+            return AppleTokenVerificationResponse.builder()
+                .isValid(true)
+                .userId(claims.getSubject())
+                .email(claims.get("email", String.class))
+                .emailVerified(claims.get("email_verified", Boolean.class))
+                .issuer(claims.getIssuer())
+                .audience(claims.getAudience() != null ? claims.getAudience().toString() : null)
+                .issuedAt(claims.getIssuedAt())
+                .expiresAt(claims.getExpiration())
+                .verifiedAt(new Date())
+                .errorMessage(null)
+                .build();
+                
+        } catch (Exception e) {
+            log.error("Apple token verification failed: {}", e.getMessage(), e);
+            
+            // 검증 실패 응답 생성
+            return AppleTokenVerificationResponse.builder()
+                .isValid(false)
+                .verifiedAt(new Date())
+                .errorMessage(e.getMessage())
+                .build();
         }
     }
     


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
- 애플 Identity Token 검증용 테스트 API 엔드포인트 (`/api/auth/apple/verify`) 구현
- 토큰 검증 결과를 담을 응답 DTO (`AppleTokenVerificationResponse`) 생성
- `AuthService` 인터페이스에 토큰 검증 메서드 추가
- `AuthServiceImpl`에 토큰 검증 메서드 구현
- `AppleOAuthClient`에 `AppleJwtUtils` 접근을 위한 getter 메서드 추가


## 🔗 관련 이슈
- Closes #39 

## ✨ 변경사항
### 추가한 것
- [ ] 

### 수정한 것  
- [ ] 

### 삭제한 것
- [ ] 

## 🧪 테스트
### 내가 확인한 것들
- [ ] 로컬에서 잘 돌아간다
- [ ] 에러 없이 실행된다
- [ ] 예상한 대로 동작한다

### 테스트 시나리오
<!-- 어떻게 테스트 했는지 간단히 적어주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (있다면)
<!-- API 테스트 결과나 화면 캡처가 있다면 첨부해주세요 -->


## 🤔 리뷰어가 특히 봐줬으면 하는 부분
<!-- 궁금하거나 확신이 서지 않는 부분을 적어주세요 -->
- 주의: 나중에 애플 OAuth값 설정값 필요함

## 📚 참고한 자료
<!-- 구글링한 링크나 참고한 문서가 있다면 적어주세요 -->


---

## ✅ 체크리스트 (PR 올리기 전에 확인)
- [ ] 코드가 잘 돌아간다
- [ ] 커밋 메시지를 의미있게 썼다  
- [ ] 불필요한 파일은 제외했다
- [ ] 다른 기능을 망가뜨리지 않는다

## 🙋‍♀️ 리뷰어에게
<!-- 리뷰어가 알았으면 하는 내용을 자유롭게 적어주세요 -->


 