### PR TITLE
FEAT: 계약서 소유자 검증 로직 구현

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/controller/ContractController.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/controller/ContractController.java
@@ -52,7 +52,7 @@ public class ContractController {
         
         Long userId = extractUserIdFromToken(authorization);
         
-        OcrContentResponse response = documentProcessService.getOcrResults(contractId);
+        OcrContentResponse response = documentProcessService.getOcrResults(contractId, userId);
         return ApiResponse.success(response, SuccessCode.SUCCESS);
     }
 
@@ -68,7 +68,7 @@ public class ContractController {
         
         Long userId = extractUserIdFromToken(authorization);
         
-        documentProcessService.updateOcrContent(contractId, request);
+        documentProcessService.updateOcrContent(contractId, request, userId);
         return ApiResponse.success(SuccessCode.SUCCESS);
     }
 
@@ -83,7 +83,7 @@ public class ContractController {
         
         Long userId = extractUserIdFromToken(authorization);
         
-        AnalysisResponse response = documentProcessService.requestAnalysis(request);
+        AnalysisResponse response = documentProcessService.requestAnalysis(request, userId);
         return ApiResponse.success(response, SuccessCode.SUCCESS);
     }
 
@@ -99,7 +99,7 @@ public class ContractController {
         
         Long userId = extractUserIdFromToken(authorization);
         
-        AnalysisResultResponse response = documentProcessService.getAnalysisResult(contractId, analysisId);
+        AnalysisResultResponse response = documentProcessService.getAnalysisResult(contractId, analysisId, userId);
         return ApiResponse.success(response, SuccessCode.SUCCESS);
     }
 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/exception/ContractAccessDeniedException.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/exception/ContractAccessDeniedException.java
@@ -1,0 +1,38 @@
+package com.sbpb.ddobak.server.domain.documentProcess.exception;
+
+import com.sbpb.ddobak.server.common.exception.BusinessException;
+
+/**
+ * 계약서 접근 권한이 없을 때 발생하는 예외
+ */
+public class ContractAccessDeniedException extends BusinessException {
+    
+    /**
+     * 기본 생성자
+     */
+    public ContractAccessDeniedException() {
+        super(DocumentProcessErrorCode.CONTRACT_OWNER_MISMATCH);
+    }
+    
+    /**
+     * 커스텀 메시지를 사용하는 생성자
+     * 
+     * @param message 상세 메시지
+     */
+    public ContractAccessDeniedException(String message) {
+        super(DocumentProcessErrorCode.CONTRACT_OWNER_MISMATCH, message);
+    }
+    
+    /**
+     * 계약서 ID와 사용자 ID로 예외 생성
+     * 
+     * @param contractId 계약서 ID
+     * @param userId 사용자 ID
+     */
+    public ContractAccessDeniedException(String contractId, Long userId) {
+        super(DocumentProcessErrorCode.CONTRACT_OWNER_MISMATCH, 
+              String.format("사용자 %d는 계약서 %s에 접근할 권한이 없습니다", userId, contractId));
+        addProperty("contractId", contractId);
+        addProperty("userId", userId);
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/exception/DocumentProcessErrorCode.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/exception/DocumentProcessErrorCode.java
@@ -1,0 +1,41 @@
+package com.sbpb.ddobak.server.domain.documentProcess.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.sbpb.ddobak.server.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * DocumentProcess 도메인의 에러 코드 정의 (3xxx 범위)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DocumentProcessErrorCode implements ErrorCode {
+
+    // ===== 3100-3199: 계약서 관련 에러 =====
+    CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, 3100, "계약서를 찾을 수 없습니다"),
+    CONTRACT_OWNER_MISMATCH(HttpStatus.FORBIDDEN, 3101, "계약서에 접근 권한이 없습니다"),
+    CONTRACT_TYPE_INVALID(HttpStatus.BAD_REQUEST, 3102, "유효하지 않은 계약서 유형입니다"),
+    
+    // ===== 3200-3299: OCR 관련 에러 =====
+    OCR_CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, 3200, "OCR 내용을 찾을 수 없습니다"),
+    OCR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3201, "OCR 처리 중 오류가 발생했습니다"),
+    OCR_UPDATE_FAILED(HttpStatus.BAD_REQUEST, 3202, "OCR 내용 업데이트에 실패했습니다"),
+    
+    // ===== 3300-3399: 분석 관련 에러 =====
+    ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, 3300, "분석 결과를 찾을 수 없습니다"),
+    ANALYSIS_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3301, "분석 처리 중 오류가 발생했습니다"),
+    ANALYSIS_IN_PROGRESS(HttpStatus.ACCEPTED, 3302, "분석이 진행 중입니다"),
+    ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3303, "분석에 실패했습니다");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/AnalysisProcessService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/AnalysisProcessService.java
@@ -1,5 +1,6 @@
 package com.sbpb.ddobak.server.domain.documentProcess.service;
 
+import com.sbpb.ddobak.server.common.exception.ResourceNotFoundException;
 import com.sbpb.ddobak.server.common.utils.IdGenerator;
 import com.sbpb.ddobak.server.common.utils.LambdaUtil;
 import com.sbpb.ddobak.server.config.AwsConfig;
@@ -7,10 +8,13 @@ import com.sbpb.ddobak.server.domain.documentProcess.dto.analysis.AnalysisReques
 import com.sbpb.ddobak.server.domain.documentProcess.dto.analysis.AnalysisResponse;
 import com.sbpb.ddobak.server.domain.documentProcess.dto.analysis.AnalysisResultResponse;
 import com.sbpb.ddobak.server.domain.documentProcess.dto.lambda.AnalysisLambdaPayload;
+import com.sbpb.ddobak.server.domain.documentProcess.entity.Contract;
 import com.sbpb.ddobak.server.domain.documentProcess.entity.ContractAnalysis;
 import com.sbpb.ddobak.server.domain.documentProcess.entity.OcrContent;
 import com.sbpb.ddobak.server.domain.documentProcess.entity.ToxicClause;
+import com.sbpb.ddobak.server.domain.documentProcess.exception.ContractAccessDeniedException;
 import com.sbpb.ddobak.server.domain.documentProcess.repository.ContractAnalysisRepository;
+import com.sbpb.ddobak.server.domain.documentProcess.repository.ContractRepository;
 import com.sbpb.ddobak.server.domain.documentProcess.repository.OcrContentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,15 +36,18 @@ public class AnalysisProcessService {
 
     private final OcrContentRepository ocrContentRepository;
     private final ContractAnalysisRepository contractAnalysisRepository;
+    private final ContractRepository contractRepository;
     private final LambdaUtil lambdaUtil;
     private final AwsConfig awsConfig;
 
     public AnalysisProcessService(OcrContentRepository ocrContentRepository,
                                   ContractAnalysisRepository contractAnalysisRepository,
+                                  ContractRepository contractRepository,
                                   LambdaUtil lambdaUtil,
                                   AwsConfig awsConfig) {
         this.ocrContentRepository = ocrContentRepository;
         this.contractAnalysisRepository = contractAnalysisRepository;
+        this.contractRepository = contractRepository;
         this.lambdaUtil = lambdaUtil;
         this.awsConfig = awsConfig;
     }
@@ -102,10 +109,10 @@ public class AnalysisProcessService {
     public AnalysisResultResponse getAnalysisResult(String contractId, String analysisId) {
         // 분석 결과 조회
         ContractAnalysis analysis = contractAnalysisRepository.findByIdWithToxicClauses(analysisId)
-            .orElseThrow(() -> new RuntimeException("Analysis not found"));
+            .orElseThrow(() -> new ResourceNotFoundException("Analysis", "id", analysisId));
         
         if (!analysis.getContractId().equals(contractId)) {
-            throw new RuntimeException("Contract ID mismatch");
+            throw new ResourceNotFoundException("Analysis for contract", "contractId", contractId);
         }
         
         // OCR 원본 내용 조회
@@ -142,5 +149,30 @@ public class AnalysisProcessService {
         response.setToxics(toxics);
         
         return response;
+    }
+    
+    /**
+     * 계약서 소유자 검증
+     * 계약서 소유자가 아닌 경우 예외 발생
+     * 
+     * @param contractId 계약서 ID
+     * @param userId 사용자 ID
+     * @throws ResourceNotFoundException 계약서를 찾을 수 없는 경우
+     * @throws ContractAccessDeniedException 계약서 소유자가 아닌 경우
+     */
+    @Transactional(readOnly = true)
+    public void verifyContractOwner(String contractId, Long userId) {
+        log.debug("계약서 소유자 검증 - ContractId: {}, UserId: {}", contractId, userId);
+        
+        Contract contract = contractRepository.findById(contractId)
+            .orElseThrow(() -> new ResourceNotFoundException("Contract", "id", contractId));
+        
+        if (!contract.getUserId().equals(userId)) {
+            log.warn("계약서 접근 권한 없음 - ContractId: {}, 요청 UserId: {}, 소유자 UserId: {}", 
+                    contractId, userId, contract.getUserId());
+            throw new ContractAccessDeniedException(contractId, userId);
+        }
+        
+        log.debug("계약서 소유자 검증 성공 - ContractId: {}, UserId: {}", contractId, userId);
     }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/DocumentProcessService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/DocumentProcessService.java
@@ -21,21 +21,31 @@ public interface DocumentProcessService {
 
     /**
      * OCR 결과 조회
+     * @param contractId 계약서 ID
+     * @param userId 사용자 ID (소유자 검증용)
      */
-    OcrContentResponse getOcrResults(String contractId);
+    OcrContentResponse getOcrResults(String contractId, Long userId);
 
     /**
      * OCR 내용 수정
+     * @param contractId 계약서 ID
+     * @param request 수정 요청 데이터
+     * @param userId 사용자 ID (소유자 검증용)
      */
-    void updateOcrContent(String contractId, OcrUpdateRequest request);
+    void updateOcrContent(String contractId, OcrUpdateRequest request, Long userId);
 
     /**
      * 분석 요청
+     * @param request 분석 요청 데이터
+     * @param userId 사용자 ID (소유자 검증용)
      */
-    AnalysisResponse requestAnalysis(AnalysisRequest request);
+    AnalysisResponse requestAnalysis(AnalysisRequest request, Long userId);
 
     /**
      * 분석 결과 조회
+     * @param contractId 계약서 ID
+     * @param analysisId 분석 ID
+     * @param userId 사용자 ID (소유자 검증용)
      */
-    AnalysisResultResponse getAnalysisResult(String contractId, String analysisId);
+    AnalysisResultResponse getAnalysisResult(String contractId, String analysisId, Long userId);
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/DocumentProcessServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/DocumentProcessServiceImpl.java
@@ -31,22 +31,42 @@ public class DocumentProcessServiceImpl implements DocumentProcessService {
     }
 
     @Override
-    public OcrContentResponse getOcrResults(String contractId) {
+    public OcrContentResponse getOcrResults(String contractId, Long userId) {
+        // 계약서 소유자 검증
+        verifyContractOwner(contractId, userId);
         return ocrProcessService.getOcrResults(contractId);
     }
 
     @Override
-    public void updateOcrContent(String contractId, OcrUpdateRequest request) {
+    public void updateOcrContent(String contractId, OcrUpdateRequest request, Long userId) {
+        // 계약서 소유자 검증
+        verifyContractOwner(contractId, userId);
         ocrProcessService.updateOcrContent(contractId, request);
     }
 
     @Override
-    public AnalysisResponse requestAnalysis(AnalysisRequest request) {
+    public AnalysisResponse requestAnalysis(AnalysisRequest request, Long userId) {
+        // 계약서 소유자 검증
+        verifyContractOwner(request.getContractId(), userId);
         return analysisProcessService.requestAnalysis(request);
     }
 
     @Override
-    public AnalysisResultResponse getAnalysisResult(String contractId, String analysisId) {
+    public AnalysisResultResponse getAnalysisResult(String contractId, String analysisId, Long userId) {
+        // 계약서 소유자 검증
+        verifyContractOwner(contractId, userId);
         return analysisProcessService.getAnalysisResult(contractId, analysisId);
+    }
+    
+    /**
+     * 계약서 소유자 검증
+     * @param contractId 계약서 ID
+     * @param userId 사용자 ID
+     * @throws com.sbpb.ddobak.server.common.exception.ResourceNotFoundException 계약서가 존재하지 않는 경우
+     * @throws com.sbpb.ddobak.server.common.exception.BusinessException 권한이 없는 경우
+     */
+    private void verifyContractOwner(String contractId, Long userId) {
+        // 계약서 소유자 검증 로직은 OcrProcessService에 위임
+        ocrProcessService.verifyContractOwner(contractId, userId);
     }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/OcrProcessService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/OcrProcessService.java
@@ -1,5 +1,6 @@
 package com.sbpb.ddobak.server.domain.documentProcess.service;
 
+import com.sbpb.ddobak.server.common.exception.ResourceNotFoundException;
 import com.sbpb.ddobak.server.common.utils.IdGenerator;
 import com.sbpb.ddobak.server.common.utils.LambdaUtil;
 import com.sbpb.ddobak.server.common.utils.S3Util;
@@ -10,6 +11,7 @@ import com.sbpb.ddobak.server.domain.documentProcess.dto.ocr.*;
 import com.sbpb.ddobak.server.domain.documentProcess.entity.Contract;
 import com.sbpb.ddobak.server.domain.documentProcess.entity.ContractType;
 import com.sbpb.ddobak.server.domain.documentProcess.entity.OcrContent;
+import com.sbpb.ddobak.server.domain.documentProcess.exception.ContractAccessDeniedException;
 import com.sbpb.ddobak.server.domain.documentProcess.repository.ContractRepository;
 import com.sbpb.ddobak.server.domain.documentProcess.repository.OcrContentRepository;
 import org.slf4j.Logger;
@@ -264,5 +266,30 @@ public class OcrProcessService {
             log.warn("Unknown contract type: {}, using null", contractTypeStr);
             return null;
         }
+    }
+    
+    /**
+     * 계약서 소유자 검증
+     * 계약서 소유자가 아닌 경우 예외 발생
+     * 
+     * @param contractId 계약서 ID
+     * @param userId 사용자 ID
+     * @throws ResourceNotFoundException 계약서를 찾을 수 없는 경우
+     * @throws ContractAccessDeniedException 계약서 소유자가 아닌 경우
+     */
+    @Transactional(readOnly = true)
+    public void verifyContractOwner(String contractId, Long userId) {
+        log.debug("계약서 소유자 검증 - ContractId: {}, UserId: {}", contractId, userId);
+        
+        Contract contract = contractRepository.findById(contractId)
+            .orElseThrow(() -> new ResourceNotFoundException("Contract", "id", contractId));
+        
+        if (!contract.getUserId().equals(userId)) {
+            log.warn("계약서 접근 권한 없음 - ContractId: {}, 요청 UserId: {}, 소유자 UserId: {}", 
+                    contractId, userId, contract.getUserId());
+            throw new ContractAccessDeniedException(contractId, userId);
+        }
+        
+        log.debug("계약서 소유자 검증 성공 - ContractId: {}, UserId: {}", contractId, userId);
     }
 } 


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
- `DocumentProcess` 도메인에 에러 코드 및 예외 클래스 추가
- 서비스 인터페이스에 사용자 검증을 위한 userId 추가
- `OcrProcessService`와 `AnalysisProcessService`에 계약서 소유자 검증 로직 구현
- 컨트롤러에서 서비스 호출 시 userId 전달

## 🔗 관련 이슈
- Closes #43 