### PR TITLE
FEAT: 토큰 관리 개선

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/entity/UserToken.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/entity/UserToken.java
@@ -1,0 +1,89 @@
+package com.sbpb.ddobak.server.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 사용자 토큰 엔티티
+ * 리프레시 토큰 및 만료 정보 관리
+ */
+@Entity
+@Table(name = "user_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(length = 500)
+    private String refreshToken;
+
+    private Instant expiryDate;
+    
+    private Instant absoluteExpiryDate;
+    
+    private Instant lastUsedAt;
+    
+    @Column(nullable = false)
+    private boolean isValid;
+    
+    @Builder
+    public UserToken(Long userId, String refreshToken, Instant expiryDate, 
+                     Instant absoluteExpiryDate, Instant lastUsedAt, boolean isValid) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+        this.expiryDate = expiryDate;
+        this.absoluteExpiryDate = absoluteExpiryDate;
+        this.lastUsedAt = lastUsedAt;
+        this.isValid = isValid;
+    }
+    
+    @PrePersist
+    protected void onCreate() {
+        if (lastUsedAt == null) {
+            lastUsedAt = Instant.now();
+        }
+        if (isValid == false) {
+            isValid = true;
+        }
+    }
+    
+    /**
+     * 리프레시 토큰 업데이트
+     * @param refreshToken 새 리프레시 토큰
+     * @param expiryDate 만료 시간
+     */
+    public void updateRefreshToken(String refreshToken, Instant expiryDate) {
+        this.refreshToken = refreshToken;
+        this.expiryDate = expiryDate;
+        this.lastUsedAt = Instant.now();
+        this.isValid = true;
+    }
+    
+    /**
+     * 토큰 무효화
+     * 로그아웃 또는 보안 문제 발생 시 호출
+     */
+    public void invalidateToken() {
+        this.isValid = false;
+        this.refreshToken = null;
+    }
+    
+    /**
+     * 절대 만료 시간 업데이트 🌟
+     * @param absoluteExpiryDate 절대 만료 시간
+     */
+    public void updateAbsoluteExpiryDate(Instant absoluteExpiryDate) {
+        this.absoluteExpiryDate = absoluteExpiryDate;
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,35 @@
+package com.sbpb.ddobak.server.domain.auth.exception;
+
+import com.sbpb.ddobak.server.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 인증 관련 에러 코드 정의 (1xxx 범위)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    // 인증 관련 에러 코드 (1100-1199)
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1100, "Invalid token"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 1101, "Token has expired"),
+    TOKEN_REUSED(HttpStatus.UNAUTHORIZED, 1102, "Token reuse detected"),
+    ABSOLUTE_EXPIRY_EXCEEDED(HttpStatus.UNAUTHORIZED, 1103, "Absolute token lifetime exceeded"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1104, "Invalid refresh token"),
+    
+    // OAuth 관련 에러 코드 (1200-1299)
+    OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, 1200, "OAuth authentication failed"),
+    INVALID_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, 1201, "Invalid OAuth provider"),
+    OAUTH_USER_INFO_RETRIEVAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1202, "Failed to retrieve OAuth user info");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/exception/TokenException.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/exception/TokenException.java
@@ -1,0 +1,53 @@
+package com.sbpb.ddobak.server.domain.auth.exception;
+
+import com.sbpb.ddobak.server.common.exception.BusinessException;
+import com.sbpb.ddobak.server.common.exception.ErrorCode;
+
+/**
+ * 토큰 관련 예외 클래스
+ */
+public class TokenException extends BusinessException {
+    
+    public TokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    
+    public TokenException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+    
+    /**
+     * 유효하지 않은 토큰 예외
+     */
+    public static TokenException invalidToken() {
+        return new TokenException(AuthErrorCode.INVALID_TOKEN);
+    }
+    
+    /**
+     * 만료된 토큰 예외
+     */
+    public static TokenException expiredToken() {
+        return new TokenException(AuthErrorCode.EXPIRED_TOKEN);
+    }
+    
+    /**
+     * 토큰 재사용 감지 예외
+     */
+    public static TokenException tokenReused() {
+        return new TokenException(AuthErrorCode.TOKEN_REUSED);
+    }
+    
+    /**
+     * 절대 만료 기간 초과 예외
+     */
+    public static TokenException absolutelyExpired() {
+        return new TokenException(AuthErrorCode.ABSOLUTE_EXPIRY_EXCEEDED);
+    }
+    
+    /**
+     * 유효하지 않은 리프레시 토큰 예외
+     */
+    public static TokenException invalidRefreshToken() {
+        return new TokenException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/repository/UserTokenRepository.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/repository/UserTokenRepository.java
@@ -1,0 +1,35 @@
+package com.sbpb.ddobak.server.domain.auth.repository;
+
+import com.sbpb.ddobak.server.domain.auth.entity.UserToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 사용자 토큰 레포지토리
+ * 리프레시 토큰 관리를 위한 데이터 액세스
+ */
+@Repository
+public interface UserTokenRepository extends JpaRepository<UserToken, Long> {
+    
+    /**
+     * 사용자 ID로 토큰 조회
+     * @param userId 사용자 ID
+     * @return 사용자 토큰 (Optional)
+     */
+    Optional<UserToken> findByUserId(Long userId);
+    
+    /**
+     * 리프레시 토큰으로 토큰 조회
+     * @param refreshToken 리프레시 토큰
+     * @return 사용자 토큰 (Optional)
+     */
+    Optional<UserToken> findByRefreshToken(String refreshToken);
+    
+    /**
+     * 사용자 ID로 토큰 삭제
+     * @param userId 사용자 ID
+     */
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/JwtService.java
@@ -155,4 +155,20 @@ public class JwtService {
     public long getAccessTokenExpirationInSeconds() {
         return accessTokenExpiration / 1000;
     }
+    
+    /**
+     * Refresh Token 만료 시간 반환 (밀리초 단위)
+     * @return 만료 시간
+     */
+    public long getRefreshTokenExpirationInMillis() {
+        return refreshTokenExpiration;
+    }
+
+    /**
+     * 절대 만료 기간 설정 (30일) 🌟🌟🌟🌟🌟
+     * @return 절대 만료 기간 (밀리초)
+     */
+    public long getAbsoluteTokenExpirationInMillis() {
+        return 30L * 24 * 60 * 60 * 1000; // 30일
+    }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/TokenService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/TokenService.java
@@ -1,0 +1,62 @@
+package com.sbpb.ddobak.server.domain.auth.service;
+
+import java.time.Instant;
+
+/**
+ * 토큰 관리 서비스 인터페이스
+ * 리프레시 토큰의 저장, 검증, 무효화 등을 담당
+ */
+public interface TokenService {
+    
+    /**
+     * 리프레시 토큰 저장
+     * @param userId 사용자 ID
+     * @param refreshToken 리프레시 토큰
+     * @param expirationTimeMillis 만료 시간 (밀리초)
+     */
+    void saveRefreshToken(Long userId, String refreshToken, long expirationTimeMillis);
+    
+    /**
+     * 사용자의 리프레시 토큰 조회
+     * @param userId 사용자 ID
+     * @return 리프레시 토큰 (없으면 null)
+     */
+    String getRefreshToken(Long userId);
+    
+    /**
+     * 리프레시 토큰 무효화
+     * @param userId 사용자 ID
+     */
+    void invalidateRefreshToken(Long userId);
+    
+    /**
+     * 토큰 재사용 감지
+     * 보안을 위해 저장된 토큰과 제공된 토큰이 다른지 확인
+     * @param userId 사용자 ID
+     * @param refreshToken 검증할 리프레시 토큰
+     * @return 토큰 재사용 여부
+     */
+    boolean isTokenReused(Long userId, String refreshToken);
+    
+    /**
+     * 절대 만료 시간 설정
+     * 토큰 재발급 횟수와 상관없이 일정 기간 후 재로그인 필요
+     * @param userId 사용자 ID
+     * @param expiryTimeMillis 절대 만료 시간 (밀리초)
+     */
+    void setAbsoluteExpiry(Long userId, long expiryTimeMillis);
+    
+    /**
+     * 절대 만료 여부 확인
+     * @param userId 사용자 ID
+     * @return 절대 만료 여부
+     */
+    boolean isAbsolutelyExpired(Long userId);
+    
+    /**
+     * 토큰 만료 시간 조회
+     * @param userId 사용자 ID
+     * @return 만료 시간
+     */
+    Instant getTokenExpiryDate(Long userId);
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
@@ -3,10 +3,12 @@ package com.sbpb.ddobak.server.domain.auth.service.impl;
 import com.sbpb.ddobak.server.domain.auth.dto.AppleLoginRequest;
 import com.sbpb.ddobak.server.domain.auth.dto.AppleTokenVerificationResponse;
 import com.sbpb.ddobak.server.domain.auth.dto.AuthResponse;
+import com.sbpb.ddobak.server.domain.auth.exception.TokenException;
 import com.sbpb.ddobak.server.domain.auth.oauth.AppleOAuthClient;
 import com.sbpb.ddobak.server.domain.auth.oauth.OAuthUserInfo;
 import com.sbpb.ddobak.server.domain.auth.service.AuthService;
 import com.sbpb.ddobak.server.domain.auth.service.JwtService;
+import com.sbpb.ddobak.server.domain.auth.service.TokenService;
 import com.sbpb.ddobak.server.domain.user.entity.User;
 import com.sbpb.ddobak.server.domain.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
@@ -29,6 +31,7 @@ public class AuthServiceImpl implements AuthService {
     
     private final AppleOAuthClient appleOAuthClient;
     private final JwtService jwtService;
+    private final TokenService tokenService;
     private final UserRepository userRepository;
     
     @Override
@@ -48,6 +51,19 @@ public class AuthServiceImpl implements AuthService {
             // 4. JWT 토큰 생성
             String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
             String refreshToken = jwtService.generateRefreshToken(user.getId());
+            
+            // 5. 리프레시 토큰 저장
+            tokenService.saveRefreshToken(
+                user.getId(), 
+                refreshToken, 
+                jwtService.getRefreshTokenExpirationInMillis()
+            );
+            
+            // 6. 절대 만료 기간 설정 (최초 로그인 또는 재로그인 시)
+            tokenService.setAbsoluteExpiry(
+                user.getId(), 
+                jwtService.getAbsoluteTokenExpirationInMillis()
+            );
             
             log.info("Apple login successful for user: {} ({})", user.getEmail(), user.getId());
             
@@ -71,7 +87,7 @@ public class AuthServiceImpl implements AuthService {
         try {
             // 1. Refresh Token 검증
             if (!jwtService.isTokenValid(refreshToken) || !jwtService.isRefreshToken(refreshToken)) {
-                throw new RuntimeException("Invalid refresh token");
+                throw TokenException.invalidRefreshToken();
             }
             
             // 2. 사용자 정보 조회
@@ -79,14 +95,34 @@ public class AuthServiceImpl implements AuthService {
             User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
             
-            // 3. 새로운 Access Token 생성
+            // 3. 토큰 재사용 감지 (보안 강화)
+            if (tokenService.isTokenReused(userId, refreshToken)) {
+                tokenService.invalidateRefreshToken(userId);
+                throw TokenException.tokenReused();
+            }
+            
+            // 4. 절대 만료 시간 확인
+            if (tokenService.isAbsolutelyExpired(userId)) {
+                tokenService.invalidateRefreshToken(userId);
+                throw TokenException.absolutelyExpired();
+            }
+            
+            // 5. 새 액세스 토큰 생성
             String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+            
+            // 6. 새 리프레시 토큰 생성 (토큰 순환 전략)
+            String newRefreshToken = jwtService.generateRefreshToken(user.getId());
+            tokenService.saveRefreshToken(
+                user.getId(), 
+                newRefreshToken, 
+                jwtService.getRefreshTokenExpirationInMillis()
+            );
             
             log.info("Token refreshed for user: {} ({})", user.getEmail(), user.getId());
             
             return AuthResponse.builder()
                 .accessToken(newAccessToken)
-                .refreshToken(refreshToken) // 기존 Refresh Token 재사용
+                .refreshToken(newRefreshToken) // 새 리프레시 토큰 반환
                 .expiresIn(jwtService.getAccessTokenExpirationInSeconds())
                 .userId(user.getId())
                 .email(user.getEmail())
@@ -95,6 +131,9 @@ public class AuthServiceImpl implements AuthService {
                 
         } catch (Exception e) {
             log.error("Token refresh failed: {}", e.getMessage(), e);
+            if (e instanceof TokenException) {
+                throw e;
+            }
             throw new RuntimeException("Token refresh failed", e);
         }
     }
@@ -102,9 +141,12 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public void logout(String accessToken) {
         try {
-            // 현재 구현에서는 단순히 로그를 남김
-            // 추후 Redis 등을 사용한 토큰 블랙리스트 구현 가능
+            // 토큰에서 사용자 ID 추출
             Long userId = jwtService.getUserIdFromToken(accessToken);
+            
+            // 토큰 무효화
+            tokenService.invalidateRefreshToken(userId);
+            
             log.info("User logged out: {}", userId);
             
         } catch (Exception e) {

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/TokenServiceImpl.java
@@ -1,0 +1,108 @@
+package com.sbpb.ddobak.server.domain.auth.service.impl;
+
+import com.sbpb.ddobak.server.domain.auth.entity.UserToken;
+import com.sbpb.ddobak.server.domain.auth.repository.UserTokenRepository;
+import com.sbpb.ddobak.server.domain.auth.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 토큰 관리 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenServiceImpl implements TokenService {
+
+    private final UserTokenRepository userTokenRepository;
+
+    @Override
+    @Transactional
+    public void saveRefreshToken(Long userId, String refreshToken, long expirationTimeMillis) {
+        Instant expiryDate = Instant.now().plusMillis(expirationTimeMillis);
+        
+        Optional<UserToken> existingToken = userTokenRepository.findByUserId(userId);
+        
+        if (existingToken.isPresent()) {
+            UserToken token = existingToken.get();
+            token.updateRefreshToken(refreshToken, expiryDate);
+            userTokenRepository.save(token);
+            log.debug("Updated refresh token for user: {}", userId);
+        } else {
+            UserToken newToken = UserToken.builder()
+                .userId(userId)
+                .refreshToken(refreshToken)
+                .expiryDate(expiryDate)
+                .absoluteExpiryDate(Instant.now().plusMillis(30L * 24 * 60 * 60 * 1000)) // 30일 절대 만료
+                .lastUsedAt(Instant.now())
+                .isValid(true)
+                .build();
+            userTokenRepository.save(newToken);
+            log.debug("Created new refresh token for user: {}", userId);
+        }
+    }
+
+    @Override
+    public String getRefreshToken(Long userId) {
+        return userTokenRepository.findByUserId(userId)
+            .filter(UserToken::isValid)
+            .map(UserToken::getRefreshToken)
+            .orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public void invalidateRefreshToken(Long userId) {
+        userTokenRepository.findByUserId(userId)
+            .ifPresent(token -> {
+                token.invalidateToken();
+                userTokenRepository.save(token);
+                log.debug("Invalidated refresh token for user: {}", userId);
+            });
+    }
+
+    @Override
+    public boolean isTokenReused(Long userId, String refreshToken) {
+        return userTokenRepository.findByUserId(userId)
+            .map(token -> token.isValid() && token.getRefreshToken() != null && !token.getRefreshToken().equals(refreshToken))
+            .orElse(false);
+    }
+
+    @Override
+    @Transactional
+    public void setAbsoluteExpiry(Long userId, long expiryTimeMillis) {
+        Instant expiryDate = Instant.now().plusMillis(expiryTimeMillis);
+        
+        userTokenRepository.findByUserId(userId)
+            .ifPresentOrElse(
+                token -> {
+                    token.updateAbsoluteExpiryDate(expiryDate);
+                    userTokenRepository.save(token);
+                    log.debug("Updated absolute expiry date for user: {}", userId);
+                },
+                () -> {
+                    // 토큰이 없는 경우 새로 생성하지 않음
+                    log.debug("No token found for user: {} when setting absolute expiry", userId);
+                }
+            );
+    }
+
+    @Override
+    public boolean isAbsolutelyExpired(Long userId) {
+        return userTokenRepository.findByUserId(userId)
+            .map(token -> Instant.now().isAfter(token.getAbsoluteExpiryDate()))
+            .orElse(true); // 토큰이 없으면 만료된 것으로 간주
+    }
+    
+    @Override
+    public Instant getTokenExpiryDate(Long userId) {
+        return userTokenRepository.findByUserId(userId)
+            .map(UserToken::getExpiryDate)
+            .orElse(null);
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
리프레시 토큰 DB 저장 + 토큰 재발급 + 리프레시 토큰 만료 기간(30일) 설정

## 🔗 관련 이슈
- Closes #48 

## ✨ 변경사항
### 추가한 것
- 리프레시 토큰 DB 저장 기능 구현 (`UserToken` 엔티티, `UserTokenRepository`)
- 토큰 관리 서비스 추가 (`TokenService`, `TokenServiceImpl`)
- AWS RDS에 `user_token` 테이블 추가

### 수정한 것  
- 리프레시 토큰 만료 기간 설정
- 토큰 재사용 감지
- 예외처리 개선
- `/api/auth/refresh`에서 액세스 토큰과 리프레시 토큰 모두 갱신



 