### PR TITLE
bugfix: 토큰 갱신 시 기존 AccessToken 무효화

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/config/SecurityConfig.java
+++ b/src/main/java/com/sbpb/ddobak/server/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sbpb.ddobak.server.config;
 
 import com.sbpb.ddobak.server.config.security.JwtAuthenticationFilter;
 import com.sbpb.ddobak.server.domain.auth.service.JwtService;
+import com.sbpb.ddobak.server.domain.auth.service.TokenService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
     private final JwtService jwtService;
+    private final TokenService tokenService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -70,7 +72,7 @@ public class SecurityConfig {
             .formLogin(formLogin -> formLogin.disable())
             
             // JWT 인증 필터 추가
-            .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(new JwtAuthenticationFilter(jwtService, tokenService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/sbpb/ddobak/server/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sbpb/ddobak/server/config/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.sbpb.ddobak.server.config.security;
 
 import com.sbpb.ddobak.server.domain.auth.service.JwtService;
+import com.sbpb.ddobak.server.domain.auth.service.TokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 
 import lombok.extern.slf4j.Slf4j;
@@ -24,9 +26,11 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
+    private final TokenService tokenService;
 
-    public JwtAuthenticationFilter(JwtService jwtService) {
+    public JwtAuthenticationFilter(JwtService jwtService, TokenService tokenService) {
         this.jwtService = jwtService;
+        this.tokenService = tokenService;
     }
 
     @Override
@@ -45,6 +49,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             
             if (jwtService.isTokenValid(jwt)) {
                 Long userId = jwtService.getUserIdFromToken(jwt);
+                
+                // AccessToken 무효화 검증 (리프레시 토큰 갱신 후 "무조건"!! 기존 AccessToken 무효화)
+                if (!isAccessTokenStillValid(userId, jwt)) {
+                    log.debug("AccessToken이 무효화되었습니다 - 사용자 ID: {}", userId);
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+                
                 String email = null;
                 
                 try {
@@ -69,5 +81,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         
         filterChain.doFilter(request, response);
+    }
+    
+    /**
+     * AccessToken이 여전히 유효한지 확인
+     * 리프레시 토큰 갱신 후 기존 AccessToken이 무효화되었는지 검증
+     * 
+     * @param userId 사용자 ID
+     * @param accessToken AccessToken
+     * @return AccessToken 유효 여부
+     */
+    private boolean isAccessTokenStillValid(Long userId, String accessToken) {
+        try {
+            // AccessToken의 발급 시간(iat) 조회
+            Instant tokenIssuedAt = jwtService.getTokenIssuedAt(accessToken);
+            
+            // DB에서 AccessToken 무효화 기준 시간 조회
+            Instant accessTokenValidAfter = tokenService.getAccessTokenValidAfter(userId);
+            
+            // 토큰 발급 시간이 무효화 기준 시간보다 이후여야 유효
+            boolean isValid = tokenIssuedAt.isAfter(accessTokenValidAfter);
+            
+            if (!isValid) {
+                log.debug("AccessToken 무효화됨 - UserId: {}, TokenIssuedAt: {}, ValidAfter: {}", 
+                    userId, tokenIssuedAt, accessTokenValidAfter);
+            }
+            
+            return isValid;
+        } catch (Exception e) {
+            log.warn("AccessToken 유효성 검증 중 오류: {}", e.getMessage());
+            return false; // 오류 발생 시 안전하게 무효로 처리
+        }
     }
 }

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/entity/UserToken.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/entity/UserToken.java
@@ -45,9 +45,16 @@ public class UserToken {
     @Column(nullable = false)
     private boolean isMaster;
     
+    /**
+     * AccessToken 무효화 기준 시간
+     * 이 시간 이후에 발급된 AccessToken만 유효함
+     * 리프레시 토큰 갱신 시 이 값을 현재 시간으로 업데이트하여 기존 AccessToken 무효화
+     */
+    private Instant accessTokenValidAfter;
+    
     @Builder
     public UserToken(Long userId, String refreshToken, Instant expiryDate, 
-                     Instant absoluteExpiryDate, Instant lastUsedAt, boolean isValid, boolean isMaster) {
+                     Instant absoluteExpiryDate, Instant lastUsedAt, boolean isValid, boolean isMaster, Instant accessTokenValidAfter) {
         this.userId = userId;
         this.refreshToken = refreshToken;
         this.expiryDate = expiryDate;
@@ -55,6 +62,7 @@ public class UserToken {
         this.lastUsedAt = lastUsedAt;
         this.isValid = isValid;
         this.isMaster = isMaster;
+        this.accessTokenValidAfter = accessTokenValidAfter;
     }
     
     @PrePersist
@@ -102,5 +110,14 @@ public class UserToken {
      */
     public void setMaster(boolean isMaster) {
         this.isMaster = isMaster;
+    }
+    
+    /**
+     * AccessToken 무효화 기준 시간 업데이트
+     * 리프레시 토큰 갱신 시 호출하여 기존 AccessToken 무효화
+     * @param accessTokenValidAfter 새로운 기준 시간
+     */
+    public void updateAccessTokenValidAfter(Instant accessTokenValidAfter) {
+        this.accessTokenValidAfter = accessTokenValidAfter;
     }
 }

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/JwtService.java
@@ -177,4 +177,14 @@ public class JwtService {
     public long getAbsoluteTokenExpirationInMillis() {
         return 30L * 24 * 60 * 60 * 1000; // 30일
     }
+    
+    /**
+     * JWT 토큰의 발급 시간(iat) 조회
+     * @param token JWT 토큰
+     * @return 발급 시간 (Instant)
+     */
+    public Instant getTokenIssuedAt(String token) {
+        Claims claims = parseToken(token);
+        return claims.getIssuedAt().toInstant();
+    }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/TokenService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/TokenService.java
@@ -66,4 +66,19 @@ public interface TokenService {
      * @return 마스터 토큰 여부
      */
     boolean isMasterToken(Long userId);
+    
+    /**
+     * AccessToken 무효화 기준 시간 조회
+     * @param userId 사용자 ID
+     * @return AccessToken 무효화 기준 시간
+     */
+    Instant getAccessTokenValidAfter(Long userId);
+    
+    /**
+     * AccessToken 무효화 기준 시간 업데이트
+     * 리프레시 토큰 갱신 시 기존 AccessToken을 무효화하기 위해 호출
+     * @param userId 사용자 ID
+     * @param validAfter 새로운 기준 시간
+     */
+    void updateAccessTokenValidAfter(Long userId, Instant validAfter);
 }

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 
@@ -109,7 +110,12 @@ public class AuthServiceImpl implements AuthService {
             // 5. 새 액세스 토큰 생성
             String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
             
-            // 6. 마스터 토큰 여부 확인
+            // 6. 기존 AccessToken 무효화 (새 액세스 토큰 발급 시점을 기준으로 설정)
+            Instant now = Instant.now();
+            tokenService.updateAccessTokenValidAfter(userId, now);
+            log.info("AccessToken 무효화 완료 - 기준 시간: {} for user: {} ({})", now, user.getEmail(), user.getId());
+            
+            // 7. 마스터 토큰 여부 확인
             boolean isMaster = tokenService.isMasterToken(userId);
             String responseRefreshToken;
             

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/TokenServiceImpl.java
@@ -42,6 +42,7 @@ public class TokenServiceImpl implements TokenService {
                 .lastUsedAt(Instant.now())
                 .isValid(true)
                 .isMaster(false) // 기본값은 일반 토큰
+                .accessTokenValidAfter(Instant.now()) // 현재 시간부터 AccessToken 유효
                 .build();
             userTokenRepository.save(newToken);
             log.debug("Created new refresh token for user: {}", userId);
@@ -112,5 +113,28 @@ public class TokenServiceImpl implements TokenService {
         return userTokenRepository.findByUserId(userId)
             .map(UserToken::isMaster)
             .orElse(false); // 토큰이 없으면 마스터가 아님
+    }
+    
+    @Override
+    public Instant getAccessTokenValidAfter(Long userId) {
+        return userTokenRepository.findByUserId(userId)
+            .map(UserToken::getAccessTokenValidAfter)
+            .orElse(Instant.EPOCH); // 토큰이 없으면 EPOCH(1970년) 반환
+    }
+    
+    @Override
+    @Transactional
+    public void updateAccessTokenValidAfter(Long userId, Instant validAfter) {
+        userTokenRepository.findByUserId(userId)
+            .ifPresentOrElse(
+                token -> {
+                    token.updateAccessTokenValidAfter(validAfter);
+                    userTokenRepository.save(token);
+                    log.debug("Updated accessTokenValidAfter for user: {} to {}", userId, validAfter);
+                },
+                () -> {
+                    log.debug("No token found for user: {} when updating accessTokenValidAfter", userId);
+                }
+            );
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
/api/auth/refresh 호출 시, 만료기간 상관 없이 **무조건 기존 토큰 무효화**

## 🔗 관련 이슈
- Closes #50 

## ✨ 변경사항

### 1. 토큰 갱신 시
1. 새 AccessToken 생성
2. 현재 시간을 `accessTokenValidAfter`로 설정  ← 기존 AccessToken 무효화!
3. DB에 저장

### 2. 액세스 토큰 검증 시 
1. AccessToken의 `iat`(발급시간) 조회
2. DB의 `accessTokenValidAfter` 조회
3. `iat > accessTokenValidAfter `이면 유효
4. `iat <= accessTokenValidAfter` 이면 무효 (403 반환)

### 3. `user_tokens` 테이블에 `access_token_valid_after` 칼럼 추가





 