### PR TITLE
feat: 사용자 탈퇴 로직 추가

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/dto/AppleLoginRequest.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/dto/AppleLoginRequest.java
@@ -15,14 +15,14 @@ import lombok.Setter;
 public class AppleLoginRequest {
     
     /**
-     * Apple Identity Token (JWT 형식)
+     * Apple Identity Token
      * Apple에서 발급한 사용자 정보가 포함된 JWT 토큰
      */
     @NotBlank(message = "Identity token is required")
     private String identityToken;
     
     /**
-     * Apple Authorization Code (선택사항)
+     * Apple Authorization Code 
      * Refresh Token 발급을 위해 필요
      * 탈퇴 시 Apple 서버에서 계정 삭제를 위해 사용됨
      */

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/dto/AppleLoginRequest.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/dto/AppleLoginRequest.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 /**
  * Apple 로그인 요청 DTO
- * Apple Identity Token만으로 로그인 처리
+ * Apple Identity Token과 Authorization Code를 사용하여 로그인 처리
  */
 @Getter
 @Setter
@@ -20,4 +20,11 @@ public class AppleLoginRequest {
      */
     @NotBlank(message = "Identity token is required")
     private String identityToken;
+    
+    /**
+     * Apple Authorization Code (선택사항)
+     * Refresh Token 발급을 위해 필요
+     * 탈퇴 시 Apple 서버에서 계정 삭제를 위해 사용됨
+     */
+    private String authorizationCode;
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleJwtUtils.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleJwtUtils.java
@@ -3,22 +3,24 @@ package com.sbpb.ddobak.server.domain.auth.oauth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.KeyFactory;
+import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
 import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +41,15 @@ public class AppleJwtUtils {
     
     @Value("${apple.oauth.public-keys-url}")
     private String applePublicKeysUrl;
+    
+    @Value("${apple.oauth.team-id}")
+    private String appleTeamId;
+    
+    @Value("${apple.oauth.key-id}")
+    private String appleKeyId;
+    
+    @Value("${apple.oauth.private-key}")
+    private String applePrivateKey;
     
     private final ObjectMapper objectMapper;
     private final HttpClient httpClient = HttpClient.newHttpClient();
@@ -74,6 +85,7 @@ public class AppleJwtUtils {
      * @param token JWT 토큰
      * @return Key ID
      */
+    @SuppressWarnings("unchecked")
     private String extractKeyIdFromToken(String token) {
         try {
             String[] parts = token.split("\\.");
@@ -91,6 +103,7 @@ public class AppleJwtUtils {
      * @param keyId Apple 공개키의 Key ID
      * @return RSA 공개키
      */
+    @SuppressWarnings("unchecked")
     private PublicKey getApplePublicKey(String keyId) throws Exception {
         // Apple 공개키 엔드포인트 호출
         HttpRequest request = HttpRequest.newBuilder()
@@ -137,5 +150,60 @@ public class AppleJwtUtils {
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         
         return keyFactory.generatePublic(keySpec);
+    }
+    
+    /**
+     * Apple Client Secret JWT 생성
+     * Token Revocation API 호출 시 필요한 client_secret 생성
+     * @return Client Secret JWT
+     * @throws Exception 키 파싱 또는 JWT 생성 실패 시
+     */
+    public String generateClientSecret() throws Exception {
+        Instant now = Instant.now();
+        Instant expiration = now.plusSeconds(15777000); // 6개월
+        
+        // Private Key 파싱
+        PrivateKey privateKey = parsePrivateKey(applePrivateKey);
+        
+        // JWT 생성
+        return Jwts.builder()
+            .header()
+                .add("kid", appleKeyId)
+                .add("alg", "ES256")
+                .and()
+            .issuer(appleTeamId)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiration))
+            .audience().add("https://appleid.apple.com").and()
+            .subject(appleClientId)
+            .signWith(privateKey, Jwts.SIG.ES256)
+            .compact();
+    }
+    
+    /**
+     * Apple Private Key (.p8 파일 내용) 파싱
+     * @param privateKeyContent Private Key 내용 (PEM 형식 또는 Base64)
+     * @return PrivateKey 객체
+     */
+    private PrivateKey parsePrivateKey(String privateKeyContent) throws Exception {
+        try {
+            // PEM 형식의 헤더/푸터 제거
+            String privateKeyPEM = privateKeyContent
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+            
+            // Base64 디코딩
+            byte[] encoded = Base64.getDecoder().decode(privateKeyPEM);
+            
+            // EC Private Key 생성
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            
+            return keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            log.error("Failed to parse Apple private key: {}", e.getMessage());
+            throw new RuntimeException("Invalid Apple private key", e);
+        }
     }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleJwtUtils.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleJwtUtils.java
@@ -181,8 +181,8 @@ public class AppleJwtUtils {
     }
     
     /**
-     * Apple Private Key (.p8 파일 내용) 파싱
-     * @param privateKeyContent Private Key 내용 (PEM 형식 또는 Base64)
+     * Apple Private Key
+     * @param privateKeyContent Private Key 내용
      * @return PrivateKey 객체
      */
     private PrivateKey parsePrivateKey(String privateKeyContent) throws Exception {

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleOAuthClient.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/oauth/AppleOAuthClient.java
@@ -5,8 +5,15 @@ import io.jsonwebtoken.Claims;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -21,6 +28,10 @@ public class AppleOAuthClient implements OAuthClient {
     @Getter
     private final AppleJwtUtils appleJwtUtils;
     private final ObjectMapper objectMapper;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    
+    @Value("${apple.oauth.client-id}")
+    private String appleClientId;
     
     @Override
     public String getProviderName() {
@@ -64,6 +75,7 @@ public class AppleOAuthClient implements OAuthClient {
      * @param claims JWT 클레임
      * @return 사용자 이름 (없으면 null)
      */
+    @SuppressWarnings("unchecked")
     private String extractNameFromClaims(Claims claims) {
         try {
             // Apple은 일반적으로 이름 정보를 JWT에 포함하지 않음
@@ -88,5 +100,104 @@ public class AppleOAuthClient implements OAuthClient {
             log.warn("Failed to extract name from Apple claims: {}", e.getMessage());
             return null;
         }
+    }
+    
+    /**
+     * Authorization Code를 사용하여 Apple Access Token 및 Refresh Token 발급
+     * @param authorizationCode Apple에서 받은 Authorization Code
+     * @return Apple Token Response (access_token, refresh_token 포함)
+     * @throws Exception Token 발급 실패 시
+     */
+    @SuppressWarnings("unchecked")
+    public AppleTokenResponse getTokens(String authorizationCode) throws Exception {
+        try {
+            String clientSecret = appleJwtUtils.generateClientSecret();
+            
+            // Request Body 생성 (application/x-www-form-urlencoded)
+            String requestBody = "client_id=" + URLEncoder.encode(appleClientId, StandardCharsets.UTF_8)
+                + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+                + "&code=" + URLEncoder.encode(authorizationCode, StandardCharsets.UTF_8)
+                + "&grant_type=authorization_code";
+            
+            // HTTP Request 생성
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://appleid.apple.com/auth/token"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+            
+            // HTTP Request 전송
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            
+            if (response.statusCode() != 200) {
+                log.error("Failed to get Apple tokens. Status: {}, Body: {}", response.statusCode(), response.body());
+                throw new RuntimeException("Failed to get Apple tokens: " + response.body());
+            }
+            
+            // Response 파싱
+            Map<String, Object> responseMap = objectMapper.readValue(response.body(), Map.class);
+            
+            return AppleTokenResponse.builder()
+                .accessToken((String) responseMap.get("access_token"))
+                .refreshToken((String) responseMap.get("refresh_token"))
+                .expiresIn((Integer) responseMap.get("expires_in"))
+                .tokenType((String) responseMap.get("token_type"))
+                .build();
+                
+        } catch (Exception e) {
+            log.error("Failed to get Apple tokens: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to get Apple tokens", e);
+        }
+    }
+    
+    /**
+     * Apple Token Revocation (계정 삭제 시 호출)
+     * @param refreshToken 사용자의 Apple Refresh Token
+     * @throws Exception Token Revocation 실패 시
+     */
+    public void revokeToken(String refreshToken) throws Exception {
+        try {
+            String clientSecret = appleJwtUtils.generateClientSecret();
+            
+            // Request Body 생성 (application/x-www-form-urlencoded)
+            String requestBody = "client_id=" + URLEncoder.encode(appleClientId, StandardCharsets.UTF_8)
+                + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8)
+                + "&token=" + URLEncoder.encode(refreshToken, StandardCharsets.UTF_8)
+                + "&token_type_hint=refresh_token";
+            
+            // HTTP Request 생성
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://appleid.apple.com/auth/revoke"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+            
+            // HTTP Request 전송
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            
+            // 200 또는 400 (이미 revoke된 경우)도 성공으로 처리
+            if (response.statusCode() == 200 || response.statusCode() == 400) {
+                log.info("Apple token revoked successfully");
+            } else {
+                log.error("Failed to revoke Apple token. Status: {}, Body: {}", response.statusCode(), response.body());
+                throw new RuntimeException("Failed to revoke Apple token: " + response.body());
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to revoke Apple token: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to revoke Apple token", e);
+        }
+    }
+    
+    /**
+     * Apple Token Response DTO
+     */
+    @lombok.Builder
+    @lombok.Getter
+    public static class AppleTokenResponse {
+        private String accessToken;
+        private String refreshToken;
+        private Integer expiresIn;
+        private String tokenType;
     }
 } 

--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
@@ -45,22 +45,42 @@ public class AuthServiceImpl implements AuthService {
             // 2. 기존 사용자 조회 또는 신규 사용자 생성
             User user = findOrCreateUser(oAuthUserInfo);
             
-            // 3. 로그인 시간 업데이트
+            // 3. Authorization Code가 있으면 Apple Refresh Token 발급 및 저장
+            if (request.getAuthorizationCode() != null && !request.getAuthorizationCode().isEmpty()) {
+                try {
+                    AppleOAuthClient.AppleTokenResponse appleTokenResponse = 
+                        appleOAuthClient.getTokens(request.getAuthorizationCode());
+                    
+                    // Apple Refresh Token 저장 (계정 삭제 시 사용)
+                    user.updateAppleRefreshToken(appleTokenResponse.getRefreshToken());
+                    log.info("Apple refresh token saved for user: {} ({})", user.getEmail(), user.getId());
+                } catch (Exception e) {
+                    // Refresh Token 발급 실패 시 경고 로그만 남기고 계속 진행
+                    // (Identity Token만으로도 로그인은 가능하므로)
+                    log.warn("Failed to get Apple refresh token for user: {} ({}). Error: {}", 
+                        user.getEmail(), user.getId(), e.getMessage());
+                }
+            } else {
+                log.warn("Authorization code not provided. Apple refresh token will not be saved for user: {} ({})", 
+                    user.getEmail(), user.getId());
+            }
+            
+            // 4. 로그인 시간 업데이트
             user.updateLastLoginAt();
             userRepository.save(user);
             
-            // 4. JWT 토큰 생성
+            // 5. JWT 토큰 생성
             String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
             String refreshToken = jwtService.generateRefreshToken(user.getId());
             
-            // 5. 리프레시 토큰 저장
+            // 6. 리프레시 토큰 저장
             tokenService.saveRefreshToken(
                 user.getId(), 
                 refreshToken, 
                 jwtService.getRefreshTokenExpirationInMillis()
             );
             
-            // 6. 절대 만료 기간 설정 (최초 로그인 또는 재로그인 시)
+            // 7. 절대 만료 기간 설정 (최초 로그인 또는 재로그인 시)
             tokenService.setAbsoluteExpiry(
                 user.getId(), 
                 jwtService.getAbsoluteTokenExpirationInMillis()

--- a/src/main/java/com/sbpb/ddobak/server/domain/user/entity/User.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/user/entity/User.java
@@ -35,6 +35,9 @@ public class User {
     @Column(name = "oauth_provider_id")
     private String oauthProviderId;  // OAuth 제공자에서의 사용자 ID
 
+    @Column(name = "apple_refresh_token", length = 2048)
+    private String appleRefreshToken;  // Apple Refresh Token (계정 삭제 시 사용)
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -57,12 +60,13 @@ public class User {
 
     @Builder
     public User(String email, String name,
-                String oauthProvider, String oauthProviderId,
+                String oauthProvider, String oauthProviderId, String appleRefreshToken,
                 LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime lastLoginAt, Boolean isDeleted) {
         this.email = email;
         this.name = name;
         this.oauthProvider = oauthProvider;
         this.oauthProviderId = oauthProviderId;
+        this.appleRefreshToken = appleRefreshToken;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.lastLoginAt = lastLoginAt;
@@ -130,6 +134,14 @@ public class User {
      */
     public void updateEmail(String email) {
         this.email = email;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Apple Refresh Token 업데이트
+     */
+    public void updateAppleRefreshToken(String appleRefreshToken) {
+        this.appleRefreshToken = appleRefreshToken;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/sbpb/ddobak/server/domain/user/service/UserService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/user/service/UserService.java
@@ -2,12 +2,12 @@ package com.sbpb.ddobak.server.domain.user.service;
 
 import com.sbpb.ddobak.server.common.exception.DuplicateResourceException;
 import com.sbpb.ddobak.server.common.exception.ResourceNotFoundException;
+import com.sbpb.ddobak.server.domain.auth.oauth.AppleOAuthClient;
 import com.sbpb.ddobak.server.domain.auth.service.JwtService;
 import com.sbpb.ddobak.server.domain.user.dto.CreateUserRequest;
 import com.sbpb.ddobak.server.domain.user.dto.UserProfileRequest;
 import com.sbpb.ddobak.server.domain.user.dto.UserProfileResponse;
 import com.sbpb.ddobak.server.domain.user.dto.UserResponse;
-import com.sbpb.ddobak.server.domain.user.dto.UserAnalysesRequest;
 import com.sbpb.ddobak.server.domain.user.dto.UserAnalysesResponse;
 import com.sbpb.ddobak.server.domain.user.entity.User;
 import com.sbpb.ddobak.server.domain.user.repository.UserRepository;
@@ -36,6 +36,7 @@ public class UserService {
     private final JwtService jwtService;
     private final ContractAnalysisRepository contractAnalysisRepository;
     private final ToxicClauseRepository toxicClauseRepository;
+    private final AppleOAuthClient appleOAuthClient;
 
     /**
      * 사용자 생성 (테스트용)
@@ -186,6 +187,23 @@ public class UserService {
             // 이미 탈퇴한 사용자인지 확인
             if (Boolean.TRUE.equals(user.getIsDeleted())) {
                 throw new IllegalArgumentException("이미 탈퇴한 사용자입니다: " + userId);
+            }
+            
+            // Apple 사용자인 경우 Apple 서버에서 계정 삭제
+            if ("apple".equals(user.getOauthProvider()) && user.getAppleRefreshToken() != null) {
+                try {
+                    log.info("Revoking Apple token for user: {} ({})", user.getEmail(), userId);
+                    appleOAuthClient.revokeToken(user.getAppleRefreshToken());
+                    log.info("Apple token revoked successfully for user: {} ({})", user.getEmail(), userId);
+                } catch (Exception e) {
+                    // Apple Token Revocation 실패 시 경고 로그만 남기고 계속 진행
+                    // (DB에서 삭제는 진행되어야 하므로)
+                    log.warn("Failed to revoke Apple token for user: {} ({}). Error: {}", 
+                        user.getEmail(), userId, e.getMessage());
+                }
+            } else if ("apple".equals(user.getOauthProvider())) {
+                log.warn("Apple refresh token not found for user: {} ({}). Cannot revoke Apple token.", 
+                    user.getEmail(), userId);
             }
             
             // 소프트 삭제 (isDeleted = true)


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
apple 서버로 탈퇴를 요청하는 로직 추가함.
현재는 db에서만 삭제되고 apple쪽에는 여전히 데이터가 남아있는 상태임.

## ✨ 변경사항
1. `users` 테이블에 `apple_refresh_token` 칼럼 추가: apple 계정 탈퇴 시 Token Revocation API 호출용
    - 단, 기존 사용자의 apple_refresh_token 값은 NULL (NULL값이어도 로그인/탈퇴는 정상 작동, apple 서버 삭제는 안됨)
    - 새 로그인(=authCode를 보내는 사용자)부터 값이 저장됨

2. 최초 로그인 시 받은 `Authorization Code`로 `Refresh Token`을 db에 저장한다. 
3. 탈퇴 시 `refresh token`으로 Apple 서버에 탈퇴를 요청한다. 

 