### PR TITLE
탈퇴 후 재가입 시 계정 활성화하기

### DIFF
--- a/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/auth/service/impl/AuthServiceImpl.java
@@ -43,7 +43,7 @@ public class AuthServiceImpl implements AuthService {
             OAuthUserInfo oAuthUserInfo = appleOAuthClient.getUserInfo(request.getIdentityToken());
             
             // 2. 기존 사용자 조회 또는 신규 사용자 생성
-            User user = findOrCreateUser(oAuthUserInfo);
+            User user = findOrCreateUser(oAuthUserInfo, request.getAuthorizationCode());
             
             // 3. Authorization Code가 있으면 Apple Refresh Token 발급 및 저장
             if (request.getAuthorizationCode() != null && !request.getAuthorizationCode().isEmpty()) {
@@ -55,14 +55,11 @@ public class AuthServiceImpl implements AuthService {
                     user.updateAppleRefreshToken(appleTokenResponse.getRefreshToken());
                     log.info("Apple refresh token saved for user: {} ({})", user.getEmail(), user.getId());
                 } catch (Exception e) {
-                    // Refresh Token 발급 실패 시 경고 로그만 남기고 계속 진행
-                    // (Identity Token만으로도 로그인은 가능하므로)
-                    log.warn("Failed to get Apple refresh token for user: {} ({}). Error: {}", 
+                    // Refresh Token 발급 실패 시 에러 (탈퇴 시 필수이므로)
+                    log.error("Failed to get Apple refresh token for user: {} ({}). Error: {}", 
                         user.getEmail(), user.getId(), e.getMessage());
+                    throw new IllegalArgumentException("Apple refresh token 발급 실패: " + e.getMessage());
                 }
-            } else {
-                log.warn("Authorization code not provided. Apple refresh token will not be saved for user: {} ({})", 
-                    user.getEmail(), user.getId());
             }
             
             // 4. 로그인 시간 업데이트
@@ -229,22 +226,43 @@ public class AuthServiceImpl implements AuthService {
     /**
      * 기존 사용자 조회 또는 신규 사용자 생성
      * @param oAuthUserInfo OAuth로 받은 사용자 정보
+     * @param authorizationCode Apple Authorization Code (신규/재활성화 시 필수)
      * @return 사용자 엔티티
      */
-    private User findOrCreateUser(OAuthUserInfo oAuthUserInfo) {
-        // Apple Provider ID로 기존 사용자 검색
-        Optional<User> existingUser = userRepository.findByAppleId(oAuthUserInfo.getProviderId());
+    private User findOrCreateUser(OAuthUserInfo oAuthUserInfo, String authorizationCode) {
+        // Apple Provider ID로 기존 사용자 검색 (삭제된 사용자 포함)
+        Optional<User> existingUser = userRepository.findByAppleIdIncludingDeleted(oAuthUserInfo.getProviderId());
         
         if (existingUser.isPresent()) {
-            // 기존 사용자 정보 업데이트 (이메일이 변경될 수 있음)
             User user = existingUser.get();
+            
+            // 탈퇴한 사용자인 경우 재활성화 (authorizationCode 필수)
+            if (Boolean.TRUE.equals(user.getIsDeleted())) {
+                if (authorizationCode == null || authorizationCode.isEmpty()) {
+                    log.error("Authorization code required for reactivating user: {} ({})", 
+                        oAuthUserInfo.getEmail(), oAuthUserInfo.getProviderId());
+                    throw new IllegalArgumentException(
+                        "재가입 시 Apple 인증이 필요합니다. Apple 설정에서 앱 연결을 해제한 후 다시 로그인해주세요.");
+                }
+                user.reactivate();
+                log.info("User reactivated after withdrawal: {} ({})", user.getEmail(), user.getId());
+            }
+            
+            // 기존 사용자 정보 업데이트 (이메일이 변경될 수 있음)
             if (!user.getEmail().equals(oAuthUserInfo.getEmail())) {
                 user.updateEmail(oAuthUserInfo.getEmail());
                 log.info("User email updated: {} -> {}", user.getEmail(), oAuthUserInfo.getEmail());
             }
+            
             return user;
         } else {
-            // 신규 사용자 생성
+            // 신규 사용자 생성 (authorizationCode 필수)
+            if (authorizationCode == null || authorizationCode.isEmpty()) {
+                log.error("Authorization code required for new user: {}", oAuthUserInfo.getEmail());
+                throw new IllegalArgumentException(
+                    "최초 가입 시 Apple 인증이 필요합니다. Apple 로그인을 다시 시도해주세요.");
+            }
+            
             User newUser = User.builder()
                 .email(oAuthUserInfo.getEmail())
                 .name(oAuthUserInfo.getName() != null ? oAuthUserInfo.getName() : "Apple User")

--- a/src/main/java/com/sbpb/ddobak/server/domain/user/entity/User.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/user/entity/User.java
@@ -123,9 +123,21 @@ public class User {
 
     /**
      * 사용자 삭제 처리 (소프트 삭제)
+     * Apple refresh token도 함께 초기화 (이미 revoke되었으므로)
      */
     public void delete() {
         this.isDeleted = true;
+        this.appleRefreshToken = null;  // revoke 후 토큰 초기화
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 사용자 재활성화 (탈퇴 후 재가입 시)
+     * Apple refresh token을 초기화하여 재가입 시 새로운 토큰을 받도록 함
+     */
+    public void reactivate() {
+        this.isDeleted = false;
+        this.appleRefreshToken = null;  // 이전 토큰은 이미 revoke되었으므로 초기화
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/sbpb/ddobak/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/user/repository/UserRepository.java
@@ -15,22 +15,32 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     /**
-     * 이메일로 사용자 조회
+     * 이메일로 활성 사용자 조회 (삭제되지 않은 사용자만)
      */
-    Optional<User> findByEmail(String email);
+    @Query("SELECT u FROM User u WHERE u.email = :email AND u.isDeleted = false")
+    Optional<User> findByEmail(@Param("email") String email);
 
     /**
-     * 이메일 존재 여부 확인
+     * 이메일 존재 여부 확인 (활성 사용자만)
      */
-    boolean existsByEmail(String email);
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u WHERE u.email = :email AND u.isDeleted = false")
+    boolean existsByEmail(@Param("email") String email);
 
     /**
-     * Apple ID로 사용자 조회
+     * Apple ID로 활성 사용자 조회 (삭제되지 않은 사용자만)
+     * @param appleId Apple OAuth Provider ID
+     * @return 사용자 Optional
+     */
+    @Query("SELECT u FROM User u WHERE u.oauthProvider = 'apple' AND u.oauthProviderId = :appleId AND u.isDeleted = false")
+    Optional<User> findByAppleId(@Param("appleId") String appleId);
+
+    /**
+     * Apple ID로 사용자 조회 (삭제 여부 무관, 재가입 처리용)
      * @param appleId Apple OAuth Provider ID
      * @return 사용자 Optional
      */
     @Query("SELECT u FROM User u WHERE u.oauthProvider = 'apple' AND u.oauthProviderId = :appleId")
-    Optional<User> findByAppleId(@Param("appleId") String appleId);
+    Optional<User> findByAppleIdIncludingDeleted(@Param("appleId") String appleId);
 
     /**
      * OAuth 제공자와 Provider ID로 사용자 조회


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 무엇을 했나요?
<!-- 이 PR에서 한 작업을 간단히 설명해주세요 -->
탈퇴 후 재가입 시 비활성화가 풀리지 않던 문제를 해결함. 

## 🔗 관련 이슈
- Closes #55 

## ✨ 변경사항
### 추가한 것
- 신/구 사용자 가입 시: authCode 필수로 설정
- `delete()`: 탈퇴 시 appleRefreshToken = null
- `reactivate()`: 재가입 시 appleRefreshToken = null
- 재가입 시 authCode 기반으로 refreshToken 발급 받아 저장: 새토큰으로 처리

